### PR TITLE
deploy to clojars directly

### DIFF
--- a/.circleci/bin/add-key
+++ b/.circleci/bin/add-key
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Settings
+knownhosts=$HOME/.ssh/known_hosts
+
+if [ "x$1" == "x-h" ] || [ "x$1" == "x--help" ] || [ ${#1} == 0 ]; then
+    echo "Usage: $0 <host> <fingerprint> [<port>]"
+    echo "Example: $0 github.com nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8"
+    echo "The default port is 22."
+    echo "The script will download the ssh keys from <host>, check if any match"
+    echo "the <fingerprint>, and add that one to $knownhosts."
+    exit 1
+fi
+
+# Argument handling
+host=$1
+fingerprint=$2
+port=$(if [ -n "$3" ]; then echo "$3"; else echo 22; fi)
+
+# Download the actual key (you cannot convert a fingerprint to the original key)
+keys=$(ssh-keyscan -p $port $host 2> /dev/null);
+if [ ${#keys} -lt 20 ]; then echo Error downloading keys; exit 2; fi
+
+# Find which line contains the key matching this fingerprint
+line=$(ssh-keygen -lf <(echo "$keys") | grep -n "$fingerprint" | cut -b 1-1)
+
+if [ ${#line} -gt 0 ]; then  # If there was a matching fingerprint
+    # Take that line
+    key=$(head -$line <(echo "$keys") | tail -1)
+    # Check if the key part (column 3) of that line is already in $knownhosts
+    if [ -n "$(grep "$(echo "$key" | awk '{print $3}')" $knownhosts)" ]; then
+        echo "Key already in $knownhosts."
+        exit 0
+    else
+        # Add it to known hosts
+        mkdir -p $HOME/.ssh
+        echo "$key" >> $knownhosts
+        # And tell the user what kind of key they just added
+        keytype=$(echo "$key" | awk '{print $2}')
+        echo Fingerprint verified and $keytype key added to $knownhosts
+    fi
+else  # If there was no matching fingerprint
+    echo MITM? These are the received fingerprints:
+    ssh-keygen -lf <(echo "$keys")
+    echo Generated from these received keys:
+    echo "$keys"
+    exit 1
+fi

--- a/.circleci/bin/gpg
+++ b/.circleci/bin/gpg
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# Invoked by `LEIN_GPG=$app/.circleci/bin/gpg lein deploy clojars`
+
+echo $GPG_PASSPHRASE \
+  | $REAL_GPG --pinentry-mode loopback --yes --batch --passphrase-fd=0 $@

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ workflows:
       - publish_topologies
 
       - deploy_snapshot:
+          context: clojars-deploy
           requires:
             - test
           filters:
@@ -130,6 +131,7 @@ workflows:
               ignore: /master/
 
       - deploy:
+          context: clojars-deploy
           requires:
             - checkout_tags
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,10 +54,87 @@ jobs:
           - grapher-{{ checksum "project.clj" }}
       - run: lein run -m topology-grapher.topology
 
+  checkout_tags:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - grapher-{{ checksum "project.clj" }}
+
+      # Workaround required for https://discuss.circleci.com/t/22437
+      #
+      # This is required to prevent the warning that appears about connecting
+      # to a host for the first time when we attempt to fetch the tags from
+      # github.
+      #
+      # The `add-key` script checks the fingerprint of the ssh key returned
+      # by github against the fingerprint published below on their website
+      # to protect against MITM attacks
+      #
+      #  https://help.github.com/en/articles/githubs-ssh-key-fingerprints
+      #
+      - run: |
+          .circleci/bin/add-key github.com $GITHUB_SSH_FINGERPRINT
+          git fetch --force origin "refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
+
+  deploy:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - grapher-{{ checksum "project.clj" }}
+
+      - run:
+          name: Prepare signing key
+          command: |
+            echo $GPG_PRIVATE_KEY |base64 --decode |gpg --yes --batch --import
+
+      - run:
+          name: Deploy to Clojars
+          command: |
+            export LEIN_GPG=/home/circleci/topology-grapher/.circleci/bin/gpg
+            export REAL_GPG=$(which gpg)
+
+            lein do jar, pom, deploy clojars
+
+  deploy_snapshot:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - grapher-{{ checksum "project.clj" }}
+
+      - run:
+          name: Deploy to Clojars
+          command: |
+            [ -z "$CLOJARS_USERNAME" ] || lein do jar, pom, deploy clojars
+
 workflows:
   version: 2
   test-then-deploy:
     jobs:
       - test
       - coverage
+      - checkout_tags
       - publish_topologies
+
+      - deploy_snapshot:
+          requires:
+            - test
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              ignore: /master/
+
+      - deploy:
+          requires:
+            - checkout_tags
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,13 @@ workflows:
     jobs:
       - test
       - coverage
-      - checkout_tags
+      - checkout_tags:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+
       - publish_topologies
 
       - deploy_snapshot:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,11 +93,10 @@ jobs:
 
       - run:
           name: Deploy to Clojars
-          command: |
-            export LEIN_GPG=/home/circleci/topology-grapher/.circleci/bin/gpg
-            export REAL_GPG=$(which gpg)
-
-            lein do jar, pom, deploy clojars
+          command: lein do jar, pom, deploy clojars
+          environment:
+            LEIN_GPG: /home/circleci/topology-grapher/.circleci/bin/gpg
+            REAL_GPG: /usr/bin/gpg
 
   deploy_snapshot:
     <<: *defaults

--- a/project.clj
+++ b/project.clj
@@ -40,5 +40,10 @@
          :plugins [[jonase/eastwood "0.3.5"]
                    [lein-cljfmt "0.5.7"]]}}
 
+  :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
+                                    :username :env/clojars_username
+                                    :password :env/clojars_password
+                                    :sign-releases false}]]
+
   :repositories
   {"confluent" {:url "https://packages.confluent.io/maven/"}})

--- a/project.clj
+++ b/project.clj
@@ -40,10 +40,11 @@
          :plugins [[jonase/eastwood "0.3.5"]
                    [lein-cljfmt "0.5.7"]]}}
 
-  :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
-                                    :username :env/clojars_username
-                                    :password :env/clojars_password
-                                    :sign-releases false}]]
+  :deploy-repositories
+  [["clojars" {:url "https://clojars.org/repo/"
+               :username :env/clojars_username
+               :password :env/clojars_password
+               :signing {:gpg-key "fundingcirclebot@fundingcircle.com"}}]]}
 
   :repositories
   {"confluent" {:url "https://packages.confluent.io/maven/"}})

--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
   [["clojars" {:url "https://clojars.org/repo/"
                :username :env/clojars_username
                :password :env/clojars_password
-               :signing {:gpg-key "fundingcirclebot@fundingcircle.com"}}]]}
+               :signing {:gpg-key "fundingcirclebot@fundingcircle.com"}}]]
 
   :repositories
   {"confluent" {:url "https://packages.confluent.io/maven/"}})


### PR DESCRIPTION
Adds the right CI configuration and helper scripts to deploy automatically snapshots and tagged releases to Clojars.