### PR TITLE
Trigger deployments from tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,8 +115,13 @@ workflows:
   version: 2
   test-then-deploy:
     jobs:
-      - test
+      - test:
+          filters:
+            tags:
+              only: /.*/
+
       - coverage
+      
       - checkout_tags:
           filters:
             tags:


### PR DESCRIPTION
💁 

> CircleCI does not run workflows for tags unless you explicitly specify tag filters. Additionally, if a job requires any other jobs (directly or indirectly), you must use regular expressions to specify tag filters for those jobs. Both lightweight and annotated tags are supported.

https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag