### PR TITLE
WIP: Add extra path arguments

### DIFF
--- a/src/topology_grapher/config.clj
+++ b/src/topology_grapher/config.clj
@@ -1,3 +1,3 @@
 (ns topology-grapher.config)
 
-(def work-dir "/tmp/graphs")
+(def base-directory "/tmp/graphs")

--- a/src/topology_grapher/describe.clj
+++ b/src/topology_grapher/describe.clj
@@ -10,6 +10,7 @@
   (System/getenv env-var))
 
 (defn name-for-graph
+  "Generate a human readable name for the topology"
   [graph]
   (format "%s.edn"
           (s/join "-"
@@ -21,11 +22,10 @@
 (defn git-sha [] (get-env-var "CIRCLE_SHA1"))
 (defn git-branch [] (get-env-var "CIRCLE_BRANCH"))
 
-(def base-path
-  (or (get-env-var "ZIP_OUTPUT_DIR") "/tmp/zips"))
+(def default-zip-path "/tmp/zips")
 
 (defn zipfile-path
-  [application-name]
+  [base-path application-name]
   (format "%s/%s_%s.zip"
           base-path
           application-name
@@ -44,13 +44,15 @@
 
 (defn generate-zip
   "Describe all the topologies and create a zip file with the result"
-  [topologies meta-data]
-  (let [application-name (:application meta-data)
-        graphs-by-name (gen-topologies topologies meta-data)
-        zip-file-path (zipfile-path application-name)
-        zip-file-master (format "%s/%s_%s.zip" base-path "latest" application-name)]
+  ([topologies meta-data]
+   (generate-zip topologies meta-data default-zip-path))
+  ([topologies meta-data base-path]
+   (let [application-name (:application meta-data)
+         graphs-by-name (gen-topologies topologies meta-data)
+         zip-file-path (zipfile-path base-path application-name)
+         zip-file-master (format "%s/%s_%s.zip" base-path "latest" application-name)]
 
-    (io/make-parents zip-file-path)
-    (zipit/zip-content zip-file-path graphs-by-name)
-    (when (= "master" (git-branch))
-      (zipit/zip-content zip-file-master graphs-by-name))))
+     (io/make-parents zip-file-path)
+     (zipit/zip-content zip-file-path graphs-by-name)
+     (when (= "master" (git-branch))
+       (zipit/zip-content zip-file-master graphs-by-name)))))

--- a/src/topology_grapher/render.clj
+++ b/src/topology_grapher/render.clj
@@ -42,16 +42,17 @@
   "Render the given topologies out to file"
   ([topologies]
    (render-graph topologies {:cache true :fmt "png" :mode "detail"}))
-  ([topologies {:keys [fmt mode output-file cache]}]
+  ([topologies {:keys [fmt mode output-file cache base-dir]}]
    {:pre [(modes mode) (fmts fmt) (caches cache)]}
    (let [ids (map :id topologies)
+         base-directory (or base-dir c/base-directory)
          ids-hash (md5 (s/join ids))
          filename (or output-file
-                      (format "%s/%s_%s.%s" c/work-dir mode ids-hash fmt))]
+                      (format "%s/%s_%s.%s" base-directory mode ids-hash fmt))
+         combined-graph (combined-graph-dot topologies ids mode)]
      (if (= fmt "dot")
-       (spit filename
-             (combined-graph-dot topologies ids mode))
+       (spit filename combined-graph)
        (when-not (and cache (.exists (io/file filename)))
-         (gviz/render fmt (combined-graph-dot topologies ids mode) filename)))
+         (gviz/render fmt combined-graph filename)))
 
      filename)))

--- a/src/topology_grapher/render.clj
+++ b/src/topology_grapher/render.clj
@@ -20,23 +20,18 @@
   (wrapper (map renderer gl)))
 
 (defn- combined-graph-dot
-  [topologies ids mode]
-  (let [filtered-topos
-        (filter
-         #(contains? (set ids) (:id %))
-         topologies)]
+  [topologies mode]
+  (assert (seq topologies) "Empty topology list")
+  (render-all
+   (if (= mode "detail")
+     topologies
+     (map prune-to-topology topologies))
 
-    (assert (seq filtered-topos) "could not find any topology passed in")
-    (render-all
-     (if (= mode "detail")
-       filtered-topos
-       (map prune-to-topology filtered-topos))
-
-     gviz/render-topology
-     (if (= mode "detail")
-       gviz/->digraph
-       (fn [g]
-         (gviz/->digraph g {:clusterrank "none"}))))))
+   gviz/render-topology
+   (if (= mode "detail")
+     gviz/->digraph
+     (fn [g]
+       (gviz/->digraph g {:clusterrank "none"})))))
 
 (defn render-graph
   "Render the given topologies out to file"
@@ -49,7 +44,7 @@
          ids-hash (md5 (s/join ids))
          filename (or output-file
                       (format "%s/%s_%s.%s" base-directory mode ids-hash fmt))
-         combined-graph (combined-graph-dot topologies ids mode)]
+         combined-graph (combined-graph-dot topologies mode)]
      (if (= fmt "dot")
        (spit filename combined-graph)
        (when-not (and cache (.exists (io/file filename)))

--- a/test/topology_grapher/describe_test.clj
+++ b/test/topology_grapher/describe_test.clj
@@ -32,8 +32,7 @@
            (set (list-zip-file output-zip-file 1)))))
 
   (testing "generating two zip files for master"
-    (with-redefs [sut/git-branch (constantly "master")]
-      (sut/generate-zip t/topologies t/meta-data))
+    (sut/generate-zip t/topologies t/meta-data)
 
     (is (true? (.isFile (io/file output-zip-file))))
     (is (true? (.isFile (io/file output-zip-latest))))))


### PR DESCRIPTION
Paths where we generate graphs and zips should not be hardcoded.
This PR makes sure you can override the default values with your own base paths.
The actual filename is still generated automatically and can't be changed however, which is useful for caching purposes.