### PR TITLE
Add definition of `topology-from-stream-builder` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ And you want to render have a visual idea of how this topology looks like.
    :subdomain "departement"
    :application "sample"})
 
+(defn topology-from-stream-builder
+  [stream-builder]
+  (.build (js/streams-builder* stream-builder)))
+
 ;; now we define a list of topologies to render, in this case just t1
 (def topologies
   [{:topology (topology-from-stream-builder (t1 (js/streams-builder)))


### PR DESCRIPTION
I'm glad to add a comment above the function, too, although I don't yet understand exactly whta it does.