### PR TITLE
exclude cljs specific dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:deps
- {org.clojure/clojure #:mvn{:version "1.10.0"},
-  danlentz/clj-uuid #:mvn{:version "0.1.7"},
-  digest #:mvn{:version "1.4.9"},
-  org.clojure/tools.cli #:mvn{:version "0.4.2"},
-  aysylu/loom #:mvn{:version "1.0.2"}}}
+ {org.clojure/clojure {:mvn/version "1.10.0"},
+  danlentz/clj-uuid {:mvn/version "0.1.7"},
+  digest {:mvn/version "1.4.9"},
+  org.clojure/tools.cli {:mvn/version "0.4.2"},
+  aysylu/loom {:mvn/version "1.0.2"
+               :exclusions [tailrecursion/cljs-priority-map]}}}

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  ;; of project that are using this library
                  [org.apache.kafka/kafka-streams "2.2.0" :scope "provided"]
                  [org.clojure/tools.cli "0.4.2"]
-                 [aysylu/loom "1.0.2"]]
+                 [aysylu/loom "1.0.2" :exclusions [tailrecursion/cljs-priority-map]]]
 
   :plugins [[me.arrdem/lein-git-version "2.0.8"]]
 


### PR DESCRIPTION
Just noticed that the cljs-priority-map dependency was bringing up Clojurescript as transitive dependency, which we most certainly don't need in Clojure/kafka projects.